### PR TITLE
Fix beta distribution when v < w and min, max != 0, 1.

### DIFF
--- a/src/random.js
+++ b/src/random.js
@@ -29,7 +29,7 @@
 
     exports.beta = function (v, w, min, max) {
         if (v < w) {
-            return max - (max - min) * _this.beta(w, v, min, max);
+            return max - (max - min) * _this.beta(w, v, 0, 1);
         }
         var y1 = _this.gamma(0, 1, v),
             y2 = _this.gamma(0, 1, w);


### PR DESCRIPTION
The beta distribution is incorrect when v < w.

The (max - min) expression already scales the result of the recursive call to the beta function.

Here's the code from http://ftp.arl.mil/random/random.pdf:

if ( v < w ) return xMax - ( xMax - xMin ) \* beta( w, v );

Note that the recursive call to beta(w, v) doesn't include the scaling parameters.
