### PR TITLE
Fix Bernoulli

### DIFF
--- a/src/random.js
+++ b/src/random.js
@@ -233,7 +233,7 @@
     };
 
     exports.bernoulli = function (p) {
-        return _this.uniform(0, 1) < p ? 0 : 1;
+        return _this.uniform(0, 1) < p ? 1 : 0;
     };
 
     exports.binomial = function (n, p) {


### PR DESCRIPTION
Not sure if this project is still active, but I thought it best to file this PR nonetheless.

The Bernoulli distribution should return 1 with probability `p`, not probability `1-p` (as is current behavior).  This also affects distributions that rely on the Bernoulli distribution with `p != 0.5` (namely, binomial and hypergeometric).

This bug may also indicate a need for tests beyond the return type of each function.  For example, you could test that each function is outputting approximately the correct distribution across 100K trials.
